### PR TITLE
fix: compilation with Xcode 26.4

### DIFF
--- a/Sources/RheaTime/Definitions.swift
+++ b/Sources/RheaTime/Definitions.swift
@@ -17,22 +17,31 @@ public typealias RheaFunction = @convention(c) (RheaContext) -> Void
 ///   replaced by `RheaFunction` during macro expansion. 
 public typealias RheaParameterlessFunction = @convention(c) () -> Void
 
-/// Represents the registration information for a Rhea function.
-/// - Note: The `StaticString` follows the format:
-///  "prefix.rheaTimeName.priority.isRepeatable.isAsync"
-///   - prefix: The namespace or module identifier.
-///   - rheaTimeName: The specific timing or event name.
-///   - priority: An integer indicating the execution priority.
-///   - isRepeatable: A boolean flag ('true' or 'false') indicating if the function can be called multiple times.
-///   - isAsync: A boolean flag ('true' or 'false') indicating if the function can be called asynchronously.
-/// - Example: "rhea.load.5.true.false"
-public typealias RheaRegisterInfo = (StaticString, RheaFunction)
+/// Represents the registration information stored in the `__DATA,__rheatime` section.
+/// Fields: (eventHash, priority, repeatable, isAsync, function)
+/// - eventHash: FNV-1a 64-bit hash of the event name string.
+/// - priority: Execution priority (higher values execute first).
+/// - repeatable: Whether the callback survives after first trigger.
+/// - isAsync: Whether the callback runs on a background queue.
+/// - function: The callback to execute.
+public typealias RheaRegisterInfo = (UInt64, Int, Bool, Bool, RheaFunction)
 
+/// FNV-1a 64-bit hash used to encode event names into a fixed-size integer.
+/// Identical implementations exist in both the macro plugin (compile-time)
+/// and the runtime (trigger-time) to ensure hash consistency.
+public func rheaFNV1aHash(_ string: String) -> UInt64 {
+    var hash: UInt64 = 0xcbf29ce484222325
+    for byte in string.utf8 {
+        hash ^= UInt64(byte)
+        hash &*= 0x100000001b3
+    }
+    return hash
+}
 
 /// Represents a task to be executed by the Rhea framework.
 internal struct RheaTask {
-    /// The name of the task, typically corresponding to a specific event.
-    let name: String
+    /// FNV-1a hash of the event name.
+    let eventHash: UInt64
     /// The priority of the task. Higher priority tasks are executed first.
     let priority: Int
     /// Indicates whether the task can be executed multiple times.

--- a/Sources/RheaTime/Rhea.swift
+++ b/Sources/RheaTime/Rhea.swift
@@ -88,7 +88,7 @@ public class Rhea: NSObject {
     public static func trigger(event: RheaEvent, param: Any? = nil) {
         let context = RheaContext()
         context.param = param
-        callbackForTime(event.rawValue, context: context)
+        callbackForTime(rheaFNV1aHash(event.rawValue), context: context)
     }
     
     nonisolated(unsafe) private static let lock: os_unfair_lock_t = {
@@ -97,7 +97,7 @@ public class Rhea: NSObject {
         return lock
     }()
     
-    nonisolated(unsafe) private static var tasks: [String: [RheaTask]] = [:]
+    nonisolated(unsafe) private static var tasks: [UInt64: [RheaTask]] = [:]
     private static let segmentName = "__DATA"
     private static let sectionName = "__rheatime"
 
@@ -106,17 +106,17 @@ public class Rhea: NSObject {
         registerNotifications()
         readSectionDatas()
         
-        callbackForTime(RheaEvent.load.rawValue)
+        callbackForTime(rheaFNV1aHash(RheaEvent.load.rawValue))
     }
     
     @objc
     static func rhea_premain() {
-        callbackForTime(RheaEvent.premain.rawValue)
+        callbackForTime(rheaFNV1aHash(RheaEvent.premain.rawValue))
     }
     
-    private static func callbackForTime(_ time: String, context: RheaContext = .init()) {
+    private static func callbackForTime(_ eventHash: UInt64, context: RheaContext = .init()) {
         os_unfair_lock_lock(lock)
-        guard let rheaTasks = tasks[time] else {
+        guard let rheaTasks = tasks[eventHash] else {
             os_unfair_lock_unlock(lock)
             return
         }
@@ -134,9 +134,9 @@ public class Rhea: NSObject {
         
         os_unfair_lock_lock(lock)
         if repeatableTasks.isEmpty {
-            tasks[time] = nil
+            tasks[eventHash] = nil
         } else {
-            tasks[time] = repeatableTasks
+            tasks[eventHash] = repeatableTasks
         }
         os_unfair_lock_unlock(lock)
     }
@@ -145,22 +145,15 @@ public class Rhea: NSObject {
         let rheaTimes = SectionReader.read(RheaRegisterInfo.self, segment: segmentName, section: sectionName)
         os_unfair_lock_lock(lock)
         for info in rheaTimes {
-            let string = info.0
-            let function = info.1
-            
-            let parts = string.description.components(separatedBy: CharacterSet(charactersIn: "."))
-            if parts.count == 5 {
-                let timeName = parts[1]
-                let priority = Int(parts[2]) ?? 5
-                let repeatable = Bool(parts[3]) ?? false
-                let isAsync = Bool(parts[4]) ?? false
-                let task = RheaTask(name: timeName, priority: priority, repeatable: repeatable, isAsync: isAsync, function: function)
-                var existingTasks = tasks[timeName] ?? []
-                existingTasks.append(task)
-                tasks[timeName] = existingTasks
-            } else {
-                assert(false, "Register info string should have 5 parts")
-            }
+            let eventHash = info.0
+            let priority = Int(info.1)
+            let repeatable = info.2
+            let isAsync = info.3
+            let function = info.4
+            let task = RheaTask(eventHash: eventHash, priority: priority, repeatable: repeatable, isAsync: isAsync, function: function)
+            var existingTasks = tasks[eventHash] ?? []
+            existingTasks.append(task)
+            tasks[eventHash] = existingTasks
         }
         os_unfair_lock_unlock(lock)
     }
@@ -199,7 +192,7 @@ public class Rhea: NSObject {
     private static func uikit_didFinishLaunching(_ notification: Notification) {
         let launchOptions = notification.userInfo as? [UIApplication.LaunchOptionsKey: Any]
         let context = RheaContext(launchOptions: launchOptions)
-        callbackForTime(RheaEvent.appDidFinishLaunching.rawValue, context: context)
+        callbackForTime(rheaFNV1aHash(RheaEvent.appDidFinishLaunching.rawValue), context: context)
     }
     #endif
     
@@ -208,7 +201,7 @@ public class Rhea: NSObject {
     private static func appkit_didFinishLaunching(_ notification: Notification) {
         let userInfo = notification.userInfo
         let context = RheaContext(param: userInfo)
-        callbackForTime(RheaEvent.appDidFinishLaunching.rawValue, context: context)
+        callbackForTime(rheaFNV1aHash(RheaEvent.appDidFinishLaunching.rawValue), context: context)
     }
     #endif
         
@@ -216,7 +209,7 @@ public class Rhea: NSObject {
     @objc
     private static func watchkit_didFinishLaunching(_ notification: Notification) {
         let context = RheaContext()
-        callbackForTime(RheaEvent.appDidFinishLaunching.rawValue, context: context)
+        callbackForTime(rheaFNV1aHash(RheaEvent.appDidFinishLaunching.rawValue), context: context)
     }
     #endif
 }

--- a/Sources/RheaTimeMacros/RheaTimeMacros.swift
+++ b/Sources/RheaTimeMacros/RheaTimeMacros.swift
@@ -75,11 +75,13 @@ public struct WriteTimeToSectionMacro: DeclarationMacro {
             throw MacroError(text: "Requires a closure.")
         }
         
+        let hashLiteral = fnv1aHashLiteral(time)
         let declarationString = """
         @_used 
         @_section("__DATA,__rheatime")
         \(staticString)let \(infoName): RheaRegisterInfo = (
-            "rhea.\(time).\(priority).\(repeatable).\(async)",
+            \(hashLiteral),
+            \(priority), \(repeatable), \(async),
             \(closure)
         )
         """
@@ -160,16 +162,35 @@ extension DeclarationMacro {
         """
         */
         
+        let hashLiteral = fnv1aHashLiteral(time)
         let declarationString = """
         @_used 
         @_section("__DATA,__rheatime")
         \(staticString)let \(infoName): RheaRegisterInfo = (
-            "rhea.\(time).5.false.false",
+            \(hashLiteral),
+            5, false, false,
             \(closure)
         )
         """
         return [DeclSyntax(stringLiteral: declarationString)]
     }
+}
+
+// MARK: - FNV-1a Hash (compile-time, mirrors the runtime implementation in Definitions.swift)
+
+private func fnv1aHash(_ string: String) -> UInt64 {
+    var hash: UInt64 = 0xcbf29ce484222325
+    for byte in string.utf8 {
+        hash ^= UInt64(byte)
+        hash &*= 0x100000001b3
+    }
+    return hash
+}
+
+private func fnv1aHashLiteral(_ string: String) -> String {
+    let hash = fnv1aHash(string)
+    let hex = String(hash, radix: 16)
+    return "0x" + String(repeating: "0", count: max(0, 16 - hex.count)) + hex
 }
 
 struct MacroError: Error, CustomStringConvertible {

--- a/Tests/RheaTests/Expansion.swift
+++ b/Tests/RheaTests/Expansion.swift
@@ -43,7 +43,8 @@ final class RheaTimeTests: XCTestCase {
                 @_used
                 @_section("__DATA,__rheatime")
                 static let __macro_local_4rheafMu_: RheaRegisterInfo = (
-                    "rhea.load.1.true.false",
+                    0xce0eecad70f271e9,
+                    1, true, false,
                     { context in
                         print("\\(context.param)")
                     }
@@ -74,7 +75,8 @@ final class RheaTimeTests: XCTestCase {
             @_used
             @_section("__DATA,__rheatime")
             let __macro_local_4rheafMu_: RheaRegisterInfo = (
-                "rhea.customEvent.1.true.false",
+                0x3451432e46f5873a,
+                1, true, false,
                 { _ in
                     print("~~~~ customEvent in main")
                 }
@@ -99,9 +101,10 @@ final class RheaTimeTests: XCTestCase {
             @_used
             @_section("__DATA,__rheatime")
             let __macro_local_4rheafMu_: RheaRegisterInfo = (
-                "rhea.load.5.false.false",
-                { _ in
-                    print("load~~~")
+                0xce0eecad70f271e9,
+                5, false, false,
+                { context in
+                    print(123)
                 }
             )
             """,


### PR DESCRIPTION
Swift 6.3 正式支持了 `@section` `@used`, 在新版 Xcode 编译器上, 即使使用旧的实验特性 `@_section` 也无法支持声明字符串, 因此将事件名做 FNV-1a 哈希, 以 `UInt64` 形式存储到 mach-o