### PR TITLE
feat: update for Swift 6.3 - use stable @section and @used attributes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -40,7 +40,7 @@ let package = Package(
             name: "RheaTime",
             dependencies: ["OCRhea", "RheaTimeMacros", "SectionReader"],
             path: "Sources/RheaTime",
-            swiftSettings: [.enableExperimentalFeature("SymbolLinkageMarkers")]
+            swiftSettings: []
         ),
         .target(name: "OCRhea"),
         // A test target used to develop the macro implementation.

--- a/README.md
+++ b/README.md
@@ -7,21 +7,16 @@
 A framework for triggering various timings. Inspired by ByteDance's internal framework Gaia, but implemented in a different way.
 In Greek mythology, Rhea is the daughter of Gaia, hence the name of this framework.
 
-After Swift 5.10, with the support of `@_used` `@_section` which can write data into sections, combined with Swift Macro, we can now achieve various decoupling and registration capabilities from the OC era. This framework has also been completely refactored using this approach.
-
-🟡 Currently, this capability is still an experimental Swift Feature and needs to be enabled through configuration settings. See the integration documentation for details.
+With the support of `@used` and `@section` (stable since Swift 6.3) which can write data into Mach-O sections, combined with Swift Macro, we can achieve various decoupling and registration capabilities from the OC era. This framework has been completely refactored using this approach.
 
 ## Requirements
 Xcode 26.4 + (Swift 6.3+)
 
-> **Note**: This version requires Xcode 26.4 or later with Swift 6.3+, which includes the stable `@section` and `@used` attributes (previously `@_section` and `@_used`).
-> For older Xcode versions (16.0-26.3), please use version [2.2.8](https://github.com/reers/Rhea/releases/tag/2.2.8) which uses the experimental attributes.
+> For older Xcode versions (16.0-26.3), please use version [2.2.8](https://github.com/reers/Rhea/releases/tag/2.2.8) which uses the experimental `@_section` and `@_used` attributes.
 
 iOS 13.0+, macOS 10.15+, tvOS 13.0+, visionOS 1.0+, watchOS 7.0+
 
-Swift 5.10
-
-swift-syntax 600.0.0
+swift-syntax 601.0.1+
 
 ## Basic Usage
 ```swift
@@ -223,7 +218,6 @@ External usage
 ```
 
 ### Swift Package Manager
-Enable experimental feature through `swiftSettings:[.enableExperimentalFeature("SymbolLinkageMarkers")]` in the dependent Package
 ```swift
 // Package.swift
 let package = Package(
@@ -233,16 +227,14 @@ let package = Package(
         .library(name: "RheaExtension", targets: ["RheaExtension"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/reers/Rhea.git", from: "2.2.7")
+        .package(url: "https://github.com/reers/Rhea.git", from: "3.0.0")
     ],
     targets: [
         .target(
             name: "RheaExtension",
             dependencies: [
                 .product(name: "RheaTime", package: "Rhea")
-            ],
-            // Add experimental feature enable here
-            swiftSettings:[.enableExperimentalFeature("SymbolLinkageMarkers")]
+            ]
         ),
     ]
 )
@@ -277,9 +269,7 @@ let package = Package(
             name: "Account",
             dependencies: [
                 .product(name: "RheaExtension", package: "RheaExtension")
-            ],
-            // Add experimental feature enable here
-            swiftSettings:[.enableExperimentalFeature("SymbolLinkageMarkers")]
+            ]
         ),
     ]
 )
@@ -290,11 +280,6 @@ import RheaExtension
     print("~~~~ homepageDidAppear in main")
 })
 ```
-
-In the main App Target, enable experimental feature in Build Settings:
--enable-experimental-feature SymbolLinkageMarkers
-![CleanShot 2024-10-12 at 20 39 59@2x](https://github.com/user-attachments/assets/92a382aa-b8b7-4b49-8a8f-c8587caaf2f1)
-
 
 ```swift
 // Main target usage
@@ -320,7 +305,7 @@ Add to Podfile:
 pod 'RheaTime'
 ```
 
-Since CocoaPods doesn't support using Swift Macro directly, you can compile the macro implementation into binary for use. The integration method is as follows, requiring `s.pod_target_xcconfig` to load the binary plugin of macro implementation:
+Since CocoaPods doesn't support using Swift Macro directly, you can compile the macro implementation into binary for use. The integration method is as follows, requiring `s.pod_target_xcconfig` to load the binary plugin:
 ```swift
 // RheaExtension podspec
 Pod::Spec.new do |s|
@@ -341,7 +326,7 @@ TODO: Add long description of the pod here.
 
   # Copy following config to your pod
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
 end
 ```
@@ -364,7 +349,7 @@ TODO: Add long description of the pod here.
   
   # Copy following config to your pod
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
 end
 ```
@@ -385,11 +370,7 @@ post_install do |installer|
           swift_flags.concat(plugin_flag.split)
         end
         
-        # Add SymbolLinkageMarkers experimental feature flag
-        symbol_linkage_flag = '-enable-experimental-feature SymbolLinkageMarkers'
         
-        unless swift_flags.join(' ').include?(symbol_linkage_flag)
-          swift_flags.concat(symbol_linkage_flag.split)
         end
         
         config.build_settings['OTHER_SWIFT_FLAGS'] = swift_flags

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ After Swift 5.10, with the support of `@_used` `@_section` which can write data 
 🟡 Currently, this capability is still an experimental Swift Feature and needs to be enabled through configuration settings. See the integration documentation for details.
 
 ## Requirements
-XCode 16.0 +
+Xcode 26.4 + (Swift 6.1+)
+
+> **Note**: This version requires Xcode 26.4 or later with Swift 6.1+, which includes the stable `@section` and `@used` attributes (previously `@_section` and `@_used`).
+> For older Xcode versions (16.0-26.3), please use version [2.2.8](https://github.com/reers/Rhea/releases/tag/2.2.8) which uses the experimental attributes.
 
 iOS 13.0+, macOS 10.15+, tvOS 13.0+, visionOS 1.0+, watchOS 7.0+
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ After Swift 5.10, with the support of `@_used` `@_section` which can write data 
 🟡 Currently, this capability is still an experimental Swift Feature and needs to be enabled through configuration settings. See the integration documentation for details.
 
 ## Requirements
-Xcode 26.4 + (Swift 6.1+)
+Xcode 26.4 + (Swift 6.3+)
 
-> **Note**: This version requires Xcode 26.4 or later with Swift 6.1+, which includes the stable `@section` and `@used` attributes (previously `@_section` and `@_used`).
+> **Note**: This version requires Xcode 26.4 or later with Swift 6.3+, which includes the stable `@section` and `@used` attributes (previously `@_section` and `@_used`).
 > For older Xcode versions (16.0-26.3), please use version [2.2.8](https://github.com/reers/Rhea/releases/tag/2.2.8) which uses the experimental attributes.
 
 iOS 13.0+, macOS 10.15+, tvOS 13.0+, visionOS 1.0+, watchOS 7.0+

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,21 +5,16 @@
 一个用于触发各种时机的框架. 灵感来自字节内部的框架 Gaia, 但是以不同的方式实现的.
 在希腊神话中, Rhea 是 Gaia 的女儿, 本框架也因此得名.
 
-Swift 5.10 之后, 支持了`@_used` `@_section` 可以将数据写入 section, 再结合 Swift Macro, 就可以实现 OC 时代各种解耦和的, 用于注册信息的能力了. 本框架也采用此方式进行了全面重构.
-
-🟡 目前这个能力还是 Swift 的实验 Feature, 需要通过配置项开启, 详见接入文档.
+利用 `@used` 和 `@section`（Swift 6.3 起正式支持）可以将数据写入 Mach-O section, 再结合 Swift Macro, 就可以实现 OC 时代各种解耦和的, 用于注册信息的能力了. 本框架也采用此方式进行了全面重构.
 
 ## 要求
 Xcode 26.4 + (Swift 6.3+)
 
-> **注意**: 本版本需要 Xcode 26.4 或更高版本，包含 Swift 6.3+，使用正式的 `@section` 和 `@used` 属性（之前是实验性的 `@_section` 和 `@_used`）。
-> 对于旧版 Xcode (16.0-26.3)，请使用 [2.2.8](https://github.com/reers/Rhea/releases/tag/2.2.8) 版本，该版本使用实验性属性。
+> 对于旧版 Xcode (16.0-26.3)，请使用 [2.2.8](https://github.com/reers/Rhea/releases/tag/2.2.8) 版本，该版本使用实验性的 `@_section` 和 `@_used` 属性。
 
 iOS 13.0+, macOS 10.15+, tvOS 13.0+, visionOS 1.0+, watchOS 7.0+
 
-Swift 5.10
-
-swift-syntax 600.0.0
+swift-syntax 601.0.1+
 
 ## 基本使用
 ```swift
@@ -222,7 +217,6 @@ RheaExtension
 ```
 
 ### Swift Package Manager
-在依赖的Package中通过 `swiftSettings:[.enableExperimentalFeature("SymbolLinkageMarkers")]` 开启实验feature
 ```swift
 // Package.swift
 let package = Package(
@@ -232,16 +226,14 @@ let package = Package(
         .library(name: "RheaExtension", targets: ["RheaExtension"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/reers/Rhea.git", from: "2.2.7")
+        .package(url: "https://github.com/reers/Rhea.git", from: "3.0.0")
     ],
     targets: [
         .target(
             name: "RheaExtension",
             dependencies: [
                 .product(name: "RheaTime", package: "Rhea")
-            ],
-            // 此处添加开启实验 feature
-            swiftSettings:[.enableExperimentalFeature("SymbolLinkageMarkers")]
+            ]
         ),
     ]
 )
@@ -276,9 +268,7 @@ let package = Package(
             name: "Account",
             dependencies: [
                 .product(name: "RheaExtension", package: "RheaExtension")
-            ],
-            // 此处添加开启实验 feature
-            swiftSettings:[.enableExperimentalFeature("SymbolLinkageMarkers")]
+            ]
         ),
     ]
 )
@@ -289,11 +279,6 @@ import RheaExtension
     print("~~~~ homepageDidAppear in main")
 })
 ```
-
-在主App Target中 Build Settings设置开启实验feature:
--enable-experimental-feature SymbolLinkageMarkers
-![CleanShot 2024-10-12 at 20 39 59@2x](https://github.com/user-attachments/assets/92a382aa-b8b7-4b49-8a8f-c8587caaf2f1)
-
 
 ```swift
 // 主 target 使用
@@ -340,7 +325,7 @@ TODO: Add long description of the pod here.
 
   # 复制以下 config 到你的 pod
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
 end
 ```
@@ -363,7 +348,7 @@ TODO: Add long description of the pod here.
   
   # 复制以下 config 到你的 pod
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
 end
 ```
@@ -384,11 +369,7 @@ post_install do |installer|
           swift_flags.concat(plugin_flag.split)
         end
         
-        # 添加 SymbolLinkageMarkers 实验性特性标志
-        symbol_linkage_flag = '-enable-experimental-feature SymbolLinkageMarkers'
         
-        unless swift_flags.join(' ').include?(symbol_linkage_flag)
-          swift_flags.concat(symbol_linkage_flag.split)
         end
         
         config.build_settings['OTHER_SWIFT_FLAGS'] = swift_flags

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,9 +10,9 @@ Swift 5.10 之后, 支持了`@_used` `@_section` 可以将数据写入 section, 
 🟡 目前这个能力还是 Swift 的实验 Feature, 需要通过配置项开启, 详见接入文档.
 
 ## 要求
-Xcode 26.4 + (Swift 6.1+)
+Xcode 26.4 + (Swift 6.3+)
 
-> **注意**: 本版本需要 Xcode 26.4 或更高版本，包含 Swift 6.1+，使用正式的 `@section` 和 `@used` 属性（之前是实验性的 `@_section` 和 `@_used`）。
+> **注意**: 本版本需要 Xcode 26.4 或更高版本，包含 Swift 6.3+，使用正式的 `@section` 和 `@used` 属性（之前是实验性的 `@_section` 和 `@_used`）。
 > 对于旧版 Xcode (16.0-26.3)，请使用 [2.2.8](https://github.com/reers/Rhea/releases/tag/2.2.8) 版本，该版本使用实验性属性。
 
 iOS 13.0+, macOS 10.15+, tvOS 13.0+, visionOS 1.0+, watchOS 7.0+

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,7 +10,10 @@ Swift 5.10 之后, 支持了`@_used` `@_section` 可以将数据写入 section, 
 🟡 目前这个能力还是 Swift 的实验 Feature, 需要通过配置项开启, 详见接入文档.
 
 ## 要求
-XCode 16.0 +
+Xcode 26.4 + (Swift 6.1+)
+
+> **注意**: 本版本需要 Xcode 26.4 或更高版本，包含 Swift 6.1+，使用正式的 `@section` 和 `@used` 属性（之前是实验性的 `@_section` 和 `@_used`）。
+> 对于旧版 Xcode (16.0-26.3)，请使用 [2.2.8](https://github.com/reers/Rhea/releases/tag/2.2.8) 版本，该版本使用实验性属性。
 
 iOS 13.0+, macOS 10.15+, tvOS 13.0+, visionOS 1.0+, watchOS 7.0+
 

--- a/RheaDemo/Package.swift
+++ b/RheaDemo/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/RheaDemo/Package.swift
+++ b/RheaDemo/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -21,7 +21,7 @@ let package = Package(
             dependencies: [
                 .product(name: "RheaTime", package: "RheaTime") // 正确指定产品依赖
             ],
-            swiftSettings: [.enableExperimentalFeature("SymbolLinkageMarkers")]
+            swiftSettings: []
         ),
     ]
 )

--- a/Sources/RheaTimeMacros/RheaTimeMacros.swift
+++ b/Sources/RheaTimeMacros/RheaTimeMacros.swift
@@ -77,8 +77,8 @@ public struct WriteTimeToSectionMacro: DeclarationMacro {
         
         let hashLiteral = fnv1aHashLiteral(time)
         let declarationString = """
-        @_used 
-        @_section("__DATA,__rheatime")
+        @used 
+        @section("__DATA,__rheatime")
         \(staticString)let \(infoName): RheaRegisterInfo = (
             \(hashLiteral),
             \(priority), \(repeatable), \(async),
@@ -164,8 +164,8 @@ extension DeclarationMacro {
         
         let hashLiteral = fnv1aHashLiteral(time)
         let declarationString = """
-        @_used 
-        @_section("__DATA,__rheatime")
+        @used 
+        @section("__DATA,__rheatime")
         \(staticString)let \(infoName): RheaRegisterInfo = (
             \(hashLiteral),
             5, false, false,

--- a/Tests/RheaTests/Expansion.swift
+++ b/Tests/RheaTests/Expansion.swift
@@ -40,8 +40,8 @@ final class RheaTimeTests: XCTestCase {
             class ViewController: UIViewController {
                 var name: String?
 
-                @_used
-                @_section("__DATA,__rheatime")
+                @used
+                @section("__DATA,__rheatime")
                 static let __macro_local_4rheafMu_: RheaRegisterInfo = (
                     0xce0eecad70f271e9,
                     1, true, false,
@@ -72,8 +72,8 @@ final class RheaTimeTests: XCTestCase {
             })
             """,
             expandedSource: """
-            @_used
-            @_section("__DATA,__rheatime")
+            @used
+            @section("__DATA,__rheatime")
             let __macro_local_4rheafMu_: RheaRegisterInfo = (
                 0x3451432e46f5873a,
                 1, true, false,
@@ -98,8 +98,8 @@ final class RheaTimeTests: XCTestCase {
             }
             """,
             expandedSource: """
-            @_used
-            @_section("__DATA,__rheatime")
+            @used
+            @section("__DATA,__rheatime")
             let __macro_local_4rheafMu_: RheaRegisterInfo = (
                 0xce0eecad70f271e9,
                 5, false, false,


### PR DESCRIPTION
## Changes

- Replace experimental `@_section` / `@_used` with stable `@section` / `@used`
- Remove `SymbolLinkageMarkers` experimental feature flag (now stable in Swift 6.1+)
- Update Package.swift swift-tools-version to 6.1
- Update README to require Xcode 26.4+ (Swift 6.1+)
- Note: Users on older Xcode (16.0-26.3) should use version 2.2.8

## Testing

- `swift build` passed
- `swift run` (RheaDemo) output: `111 444 222 555` — load and premain callbacks working correctly
