### PR TITLE
Distribute CocoaPods macro plugin via GitHub Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+  schedule:
+    - cron: "3 3 * * 2" # 3:03 AM, every Tuesday
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macOS:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]')
+    name: macOS (Swift ${{ matrix.swift }})
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        swift:
+          - "6.3"
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+
+      - name: Disable SwiftSyntax Prebuilts
+        run: |
+          defaults write com.apple.dt.Xcode IDEPackageEnablePrebuilts -bool NO
+
+          # nuke cache to ensure it takes effect
+          rm -rf ~/Library/Developer/Xcode/DerivedData
+          rm -rf ~/Library/Developer/Xcode/SourcePackages
+          rm -rf ~/Library/Caches/org.swift.swiftpm
+
+      - name: Run Tests
+        uses: mxcl/xcodebuild@v3
+        with:
+          platform: macOS
+          swift: ~${{ matrix.swift }}
+          action: test
+          verbosity: xcbeautify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Build and Release Macro Plugin
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-arm64:
+    name: Build arm64
+    runs-on: macos-15
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Build arm64 macro plugin
+        run: |
+          swift build -c release --product RheaTimeMacros
+          cp .build/release/RheaTimeMacros-tool ./RheaTimeMacros-arm64
+          file ./RheaTimeMacros-arm64
+
+      - name: Upload arm64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macro-plugin-arm64
+          path: RheaTimeMacros-arm64
+
+  build-x86_64:
+    name: Build x86_64
+    runs-on: macos-15-intel
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Build x86_64 macro plugin
+        run: |
+          swift build -c release --product RheaTimeMacros
+          cp .build/release/RheaTimeMacros-tool ./RheaTimeMacros-x86_64
+          file ./RheaTimeMacros-x86_64
+
+      - name: Upload x86_64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macro-plugin-x86_64
+          path: RheaTimeMacros-x86_64
+
+  create-universal-and-upload:
+    name: Create Universal Macro Plugin and Upload
+    needs: [build-arm64, build-x86_64]
+    runs-on: macos-15
+    permissions:
+      contents: write
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Download arm64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macro-plugin-arm64
+          path: ./artifacts
+
+      - name: Download x86_64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macro-plugin-x86_64
+          path: ./artifacts
+
+      - name: Create Universal Macro Plugin
+        run: |
+          cd artifacts
+
+          # Create Universal Macro Plugin
+          lipo -create RheaTimeMacros-arm64 RheaTimeMacros-x86_64 \
+               -output RheaTimeMacros
+
+          echo "=== Universal Macro Plugin Info ==="
+          lipo -info RheaTimeMacros
+          file RheaTimeMacros
+
+          # Create zip archive
+          zip RheaTimeMacros.zip RheaTimeMacros
+
+          echo "=== Zip Contents ==="
+          unzip -l RheaTimeMacros.zip
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/RheaTimeMacros.zip

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,12 @@ playground.xcworkspace
 
 .build/
 
+# Prebuilt CocoaPods macro plugin (distributed via GitHub Release)
+MacroPlugin/RheaTimeMacros
+MacroPlugin/RheaTimeMacros.zip
+Sources/Resources/RheaTimeMacros
+
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Add to Podfile:
 pod 'RheaTime'
 ```
 
-Since CocoaPods doesn't support using Swift Macro directly, you can compile the macro implementation into binary for use. The integration method is as follows, requiring `s.pod_target_xcconfig` to load the binary plugin:
+Since CocoaPods doesn't support using Swift Macro directly, RheaTime downloads a prebuilt universal macro plugin from the GitHub Release matching the pod version (with a source-build fallback). Dependent pods still need `s.pod_target_xcconfig` to load the plugin:
 ```swift
 // RheaExtension podspec
 Pod::Spec.new do |s|
@@ -326,7 +326,7 @@ TODO: Add long description of the pod here.
 
   # Copy following config to your pod
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_BUILD_DIR}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
 end
 ```
@@ -349,7 +349,7 @@ TODO: Add long description of the pod here.
   
   # Copy following config to your pod
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_BUILD_DIR}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
 end
 ```
@@ -364,7 +364,7 @@ post_install do |installer|
       target.build_configurations.each do |config|
         swift_flags = config.build_settings['OTHER_SWIFT_FLAGS'] ||= ['$(inherited)']
         
-        plugin_flag = '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+        plugin_flag = '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_BUILD_DIR}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
         
         unless swift_flags.join(' ').include?(plugin_flag)
           swift_flags.concat(plugin_flag.split)

--- a/README_CN.md
+++ b/README_CN.md
@@ -304,7 +304,7 @@ Podfile中添加:
 pod 'RheaTime'
 ```
 
-由于 CocoaPods 不支持直接使用 Swift Macro, 可以将宏实现编译为二进制提供使用, 接入方式如下, 需要设置`s.pod_target_xcconfig`来加载宏实现的二进制插件:
+由于 CocoaPods 不支持直接使用 Swift Macro，RheaTime 会从与 pod 版本对应的 GitHub Release 下载预编译的 universal 宏插件（下载失败时回退到源码构建）。依赖方仍需设置 `s.pod_target_xcconfig` 来加载该插件：
 ```swift
 // RheaExtension podspec
 Pod::Spec.new do |s|
@@ -325,7 +325,7 @@ TODO: Add long description of the pod here.
 
   # 复制以下 config 到你的 pod
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_BUILD_DIR}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
 end
 ```
@@ -348,7 +348,7 @@ TODO: Add long description of the pod here.
   
   # 复制以下 config 到你的 pod
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_BUILD_DIR}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
 end
 ```
@@ -363,7 +363,7 @@ post_install do |installer|
       target.build_configurations.each do |config|
         swift_flags = config.build_settings['OTHER_SWIFT_FLAGS'] ||= ['$(inherited)']
         
-        plugin_flag = '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+        plugin_flag = '-Xfrontend -load-plugin-executable -Xfrontend ${PODS_BUILD_DIR}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
         
         unless swift_flags.join(' ').include?(plugin_flag)
           swift_flags.concat(plugin_flag.split)

--- a/RheaTime.podspec
+++ b/RheaTime.podspec
@@ -1,5 +1,5 @@
 #
-# Be sure to run `pod lib lint Rhea.podspec' to ensure this is a
+# Be sure to run `pod lib lint RheaTime.podspec' to ensure this is a
 # valid spec before submitting.
 #
 # Any lines starting with a # are optional, but their use is encouraged
@@ -25,20 +25,72 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "7.0"
   s.tvos.deployment_target = "13.0"
   s.visionos.deployment_target = "1.0"
-  
+
   s.swift_versions = '5.10'
 
-  s.source_files = 'Sources/**/*', 'MacroPlugin/RheaTimeMacros'
-  # Macro plugin sources are SPM-only (need SwiftSyntax); CocoaPods uses MacroPlugin binary.
+  s.source_files = 'Sources/RheaTime/**/*', 'Sources/OCRhea/**/*'
+  # Macro plugin sources are SPM-only (need SwiftSyntax); CocoaPods downloads
+  # a prebuilt universal binary from GitHub Release (see script_phase below).
   s.exclude_files = 'Sources/RheaTimeMacros', 'Sources/RheaTimeMacroExpansion'
-  
+
+  s.preserve_paths = [
+    'Package.swift',
+    'Sources/RheaTimeMacros',
+    'Sources/RheaTimeMacroExpansion',
+    'Tests',
+    'MacroPlugin'
+  ]
+
   s.pod_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_BUILD_DIR}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
-  
+
   s.user_target_xcconfig = {
-    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_ROOT}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
+    'OTHER_SWIFT_FLAGS' => '-enable-experimental-feature SymbolLinkageMarkers -Xfrontend -load-plugin-executable -Xfrontend ${PODS_BUILD_DIR}/RheaTime/MacroPlugin/RheaTimeMacros#RheaTimeMacros'
   }
-  
+
+  # Download prebuilt universal macro plugin from GitHub Release
+  script = <<-SCRIPT
+    set -e
+
+    PLUGIN_DIR="${PODS_BUILD_DIR}/RheaTime/MacroPlugin"
+    PLUGIN_NAME="RheaTimeMacros"
+    VERSION="#{s.version}"
+    DOWNLOAD_URL="https://github.com/reers/Rhea/releases/download/${VERSION}/${PLUGIN_NAME}.zip"
+
+    # Check if plugin already exists
+    if [ -x "${PLUGIN_DIR}/${PLUGIN_NAME}" ]; then
+      echo "Macro plugin already exists, skipping download."
+      exit 0
+    fi
+
+    mkdir -p "${PLUGIN_DIR}"
+
+    echo "Downloading prebuilt macro plugin from ${DOWNLOAD_URL}..."
+
+    if curl -L -f --connect-timeout 3 --max-time 60 -o "${PLUGIN_DIR}/${PLUGIN_NAME}.zip" "${DOWNLOAD_URL}"; then
+      unzip -o "${PLUGIN_DIR}/${PLUGIN_NAME}.zip" -d "${PLUGIN_DIR}"
+      rm -f "${PLUGIN_DIR}/${PLUGIN_NAME}.zip"
+      chmod +x "${PLUGIN_DIR}/${PLUGIN_NAME}"
+      echo "Successfully downloaded prebuilt macro plugin"
+      file "${PLUGIN_DIR}/${PLUGIN_NAME}"
+    else
+      echo "Warning: Failed to download prebuilt macro plugin, will build from source..."
+
+      # Fallback: build from source
+      env -i PATH="$PATH" "$SHELL" -l -c "swift build -c release --package-path \\"${PODS_TARGET_SRCROOT}\\" --build-path \\"${PODS_BUILD_DIR}/RheaTime\\" --product RheaTimeMacros"
+      cp "${PODS_BUILD_DIR}/RheaTime/release/RheaTimeMacros-tool" "${PLUGIN_DIR}/${PLUGIN_NAME}"
+      chmod +x "${PLUGIN_DIR}/${PLUGIN_NAME}"
+      echo "Built macro plugin from source"
+      file "${PLUGIN_DIR}/${PLUGIN_NAME}"
+    fi
+  SCRIPT
+
+  s.script_phase = {
+    :name => 'Download RheaTimeMacros Plugin',
+    :script => script,
+    :execution_position => :before_compile
+  }
+
   s.dependency 'SectionReader'
 end


### PR DESCRIPTION
## Summary
- Stop committing the ~20MB `MacroPlugin/RheaTimeMacros` binary; CocoaPods downloads a universal build from the matching GitHub Release (ReerCodable-style), with source-build fallback.
- Add `release.yml` (arm64 + x86_64 → lipo → upload zip) and `ci.yml`.
- History was rewritten with `git filter-repo` and force-pushed; this PR lands the podspec/CI changes on `main`.

## Test plan
- [ ] Merge, retag `2.4.0` onto new `main`, recreate GitHub Release to publish `RheaTimeMacros.zip`
- [ ] Confirm release workflow uploads the zip asset
- [ ] `pod install` / lint uses downloaded plugin under `PODS_BUILD_DIR`

Made with [Cursor](https://cursor.com)